### PR TITLE
Update runtime version from 48 to 50

### DIFF
--- a/io.github.berarma.Oversteer.yaml
+++ b/io.github.berarma.Oversteer.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.berarma.Oversteer
 runtime: org.gnome.Platform
-runtime-version: '48'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 command: oversteer
 finish-args:


### PR DESCRIPTION
First of all, thanks for maintaining Oversteer. I noticed that the Flatpak build is still pointing to the GNOME 48 runtime. Since that version went EoL recently (March 24th), the system is flagging it as unsupported. It would be great if the runtime dependency could be bumped to a more recent version of org.gnome.Platform to clear those EoL warnings (The GNOME 48 runtime is no longer supported as of March 24, 2026. Please ask your application developer to migrate to a supported platform.). 

Best regards!